### PR TITLE
fix: App on deploying shows Api Version is Outdated

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
 	"id": "e664d2cb-7beb-413a-837a-80fd840c387b",
 	"version": "0.0.1",
-	"requiredApiVersion": "1.44.0",
+	"requiredApiVersion": "^1.44.0",
 	"iconFile": "icon.png",
 	"author": {
 		"name": "Vipin Chaudhary",


### PR DESCRIPTION
## Issue(s)
App shows Api version is outdated on deploying it.
[Issue-#20](https://github.com/RocketChat/Apps.QuickReplies/issues/20)


## Proposed changes (including videos or screenshots)
Changed the `requiredApiVersion` in app.json
New Behaviour 
![image](https://github.com/user-attachments/assets/6f0c31ca-27cd-4ec9-8cdc-9a1d1cd1e4d9)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->