### PR TITLE
[fix] : Filtered out self messages from AI reply generation

### DIFF
--- a/src/handlers/Handler.ts
+++ b/src/handlers/Handler.ts
@@ -16,9 +16,10 @@ import { IReply } from '../definition/reply/IReply';
 import {
 	sendDefaultNotification,
 	sendHelperNotification,
+	sendNotification,
 } from '../helper/notification';
 import { UserPreferenceModal } from '../modal/UserPreferenceModal';
-import { Language } from '../lib/Translation/translation';
+import { Language, t } from '../lib/Translation/translation';
 import { ReplyAIModal } from '../modal/AIreplyModal';
 import { AIstorage } from '../storage/AIStorage';
 import { UserPreferenceStorage } from '../storage/userPreferenceStorage';
@@ -165,14 +166,15 @@ export class Handler implements IHandler {
 		const roomMessages = await this.read
 			.getRoomReader()
 			.getMessages(roomId);
-		const lastMessage = roomMessages.pop();
+		const lastMessage = roomMessages.reverse() && roomMessages
+		.find(message => message.text &&
+			message.sender.username !== this.sender.username);
 		const Message =
 			message ||
 			lastMessage?.text ||
 			lastMessage?.attachments?.[0]?.description ||
 			'';
 		const textMessage = Message.trim();
-
 		if (textMessage) {
 			const aistorage = new AIstorage(
 				this.persis,
@@ -204,6 +206,11 @@ export class Handler implements IHandler {
 					.openSurfaceView(modal, { triggerId }, this.sender);
 			}
 			return;
+		}else{
+			const errorMessage = t('Reply_Not_Found',this.language)
+			await sendNotification(this.read, this.modify, this.sender, this.room, {
+				message: errorMessage,
+			});
 		}
 	}
 }

--- a/src/lib/Translation/locales/de.ts
+++ b/src/lib/Translation/locales/de.ts
@@ -86,6 +86,6 @@ export const de = {
     AI_Gemini_Model_Not_Configured: "Ihr Gemini-Modell ist nicht richtig eingerichtet. Bitte überprüfen Sie Ihre Konfiguration",
     AI_Workspace_Model_Not_Configured: "Ihre Workspace-AI ist nicht richtig eingerichtet. Bitte kontaktieren Sie Ihren Administrator",
     AI_Something_Went_Wrong: "Etwas ist schiefgelaufen. Bitte versuchen Sie es später noch einmal.",
-    Refresh_Button_Text: "Aktualisieren"
-
-}
+    Refresh_Button_Text: "Aktualisieren",
+    Reply_Not_Found: "Keine Nachrichten von anderen Benutzern in diesem Raum gefunden, um KI-Antwort zu generieren❌",
+};

--- a/src/lib/Translation/locales/en.ts
+++ b/src/lib/Translation/locales/en.ts
@@ -86,4 +86,6 @@ export const en = {
 	AI_Gemini_Model_Not_Configured: "Your Gemini Model is not set up properly. Please check your configuration",
 	AI_Workspace_Model_Not_Configured: "Your Workspace AI is not set up properly. Please contact your administrator",
 	AI_Something_Went_Wrong: "Something went wrong. Please try again later.",
-	Refresh_Button_Text: "Refresh"};
+	Refresh_Button_Text: "Refresh",
+	Reply_Not_Found: "No messages from other users found in this room to generate ai response❌",
+};

--- a/src/lib/Translation/locales/pl.ts
+++ b/src/lib/Translation/locales/pl.ts
@@ -86,7 +86,6 @@ export const pl = {
     AI_Gemini_Model_Not_Configured: "Twój model Gemini nie jest poprawnie skonfigurowany. Proszę sprawdzić swoją konfigurację",
     AI_Workspace_Model_Not_Configured: "Twoja AI w Workspace nie jest poprawnie skonfigurowana. Proszę skontaktować się z administratorem",
     AI_Something_Went_Wrong: "Coś poszło nie tak. Proszę spróbować ponownie później.",
-    Refresh_Button_Text: "Odśwież"
- 
-}
-
+    Refresh_Button_Text: "Odśwież",
+    Reply_Not_Found: "Nie znaleziono wiadomości od innych użytkowników w tym pokoju do wygenerowania odpowiedzi AI❌",
+};

--- a/src/lib/Translation/locales/pt.ts
+++ b/src/lib/Translation/locales/pt.ts
@@ -86,7 +86,6 @@ export const pt = {
     AI_Gemini_Model_Not_Configured: "Seu Modelo Gemini não está configurado corretamente. Por favor, verifique sua configuração",
     AI_Workspace_Model_Not_Configured: "Sua IA do Workspace não está configurada corretamente. Por favor, entre em contato com o administrador",
     AI_Something_Went_Wrong: "Algo deu errado. Por favor, tente novamente mais tarde.",
-    Refresh_Button_Text: "Atualizar"
- 
-}
-
+    Refresh_Button_Text: "Atualizar",
+    Reply_Not_Found: "Nenhuma mensagem de outros usuários encontrada nesta sala para gerar resposta de IA❌",
+};

--- a/src/lib/Translation/locales/ru.ts
+++ b/src/lib/Translation/locales/ru.ts
@@ -86,6 +86,6 @@ export const ru = {
     AI_Gemini_Model_Not_Configured: "Ваша модель Gemini не настроена должным образом. Пожалуйста, проверьте свою конфигурацию",
     AI_Workspace_Model_Not_Configured: "Ваша AI в Workspace не настроена должным образом. Пожалуйста, свяжитесь с администратором",
     AI_Something_Went_Wrong: "Что-то пошло не так. Пожалуйста, попробуйте позже.",
-    Refresh_Button_Text: "Обновить"
- 
-}
+    Refresh_Button_Text: "Обновить",
+    Reply_Not_Found: "В этой комнате не найдено сообщений от других пользователей для генерации ответа ИИ❌",
+};


### PR DESCRIPTION
## Issue(#40)

Closes #40 

## Acceptance Criteria fulfillment

- [ ] AI modal should take the last message of the other user
- [ ]  User receives a error notification when no valid messages are found to generate AI response

### What changes i made ?
- I changed the logic from poping the last message to finding the last message form a distinct user
- I also added a notification in all the languages to notify the user if there are no user message in the room

### POC - 
[Screencast from 2025-02-27 04-42-14.webm](https://github.com/user-attachments/assets/239fe321-ae25-4159-b823-4bae9329061b)


i have tested out the logic and also checked the error message in all the languages available 