### PR TITLE
Fix:  Ensure All Replies Are Displayed in /qs Command

### DIFF
--- a/src/commands/QsCommand.ts
+++ b/src/commands/QsCommand.ts
@@ -75,9 +75,7 @@ export class QsCommand implements ISlashCommand {
 
 		const matchedReplies = userReplies
 			.filter((reply) => reply.name.toLowerCase().includes(searchTerm))
-			.sort((a, b) => this.compareReplies(a, b, searchTerm))
-			.slice(0, 5);
-
+			.sort((a, b) => this.compareReplies(a, b, searchTerm));
 		const items = matchedReplies.map((reply) => ({
 			id: reply.id,
 			type: SlashCommandPreviewItemType.TEXT,


### PR DESCRIPTION
## Issue(s) #46 


<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Acceptance Criteria fulfillment

<!-- This will contain the acceptance criterias required by the Pull Request in order to close the issue. This Section can be deleted if no acceptance criteriasd are provided -->

-  Ensure all available quick replies are displayed in the /qs command.


## Proposed changes (including videos or screenshots)


https://github.com/user-attachments/assets/0802591d-6a03-4c18-918b-d856cd8d4e99



<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
