### PR TITLE
Add error message for missing attachment description and empty message

### DIFF
--- a/src/handlers/Handler.ts
+++ b/src/handlers/Handler.ts
@@ -175,7 +175,6 @@ export class Handler implements IHandler {
 		const textMessage = Message.trim();
 
 		if (textMessage) {
-            this.app.getLogger().debug(textMessage, "testMessage")
 			const aistorage = new AIstorage(
 				this.persis,
 				this.read.getPersistenceReader(),

--- a/src/handlers/Handler.ts
+++ b/src/handlers/Handler.ts
@@ -16,6 +16,7 @@ import { IReply } from '../definition/reply/IReply';
 import {
 	sendDefaultNotification,
 	sendHelperNotification,
+    sendNotification,
 } from '../helper/notification';
 import { UserPreferenceModal } from '../modal/UserPreferenceModal';
 import { Language } from '../lib/Translation/translation';
@@ -174,6 +175,7 @@ export class Handler implements IHandler {
 		const textMessage = Message.trim();
 
 		if (textMessage) {
+            this.app.getLogger().debug(textMessage, "testMessage")
 			const aistorage = new AIstorage(
 				this.persis,
 				this.read.getPersistenceReader(),
@@ -205,5 +207,19 @@ export class Handler implements IHandler {
 			}
 			return;
 		}
+        else if(lastMessage?.attachments && !lastMessage?.attachments?.[0]?.description){
+            const content = {
+                message: "Quick replies can't be used because the attachment has no description. The attachment must have a description to proceed."
+            }
+            await sendNotification(this.read, this.modify, this.sender, this.room, content);
+            return
+        }
+        else{
+            const content = {
+                message: "Quick replies can't be used because there is no message to reply to. Please try again with a valid message."
+            }
+            await sendNotification(this.read, this.modify, this.sender, this.room, content);
+            return
+        }
 	}
 }


### PR DESCRIPTION
## Issue(s)
#54 

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->


## Proposed changes (including videos or screenshots)
Here I demonstrate the changes made, showing the error messages displayed when there is no message to reply to, and when an attachment lacks a description.


https://github.com/user-attachments/assets/777ec701-2059-4854-8d37-29c40d751b07


<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
