### PR TITLE
fix: return comparison result in reply name uniqueness check

### DIFF
--- a/src/storage/ReplyStorage.ts
+++ b/src/storage/ReplyStorage.ts
@@ -70,8 +70,7 @@ export class ReplyStorage {
 
 		const replyFound = replies.find((reply) => reply.name === name);
 		if (replyFound && replyId) {
-			replyFound.id === replyId;
-			return true;
+			return replyFound.id === replyId;
 		} else if (replyFound) {
 			return false;
 		}


### PR DESCRIPTION
## Bug

In `ReplyStorage.ts`, the `isUniqueReplyName` method has a no-op comparison:

```typescript
if (replyFound && replyId) {
    replyFound.id === replyId;  // comparison result is discarded!
    return true;                // always returns true
}
```

This means when editing a reply, the uniqueness check always passes — allowing a user to rename a reply to a name that's already used by another reply.

## Fix
Return the comparison result directly:
```
if (replyFound && replyId) {
    return replyFound.id === replyId;  // true only if it's the same reply
}
```

This correctly returns true if the found reply is the same one being edited (user keeping their own name) and false if a different reply already has that name (blocking the duplicate)

## Testing
- Create two replies with different names (e.g., "Hello" and "Goodbye")
- Edit "Hello" and change its name to "Goodbye"
- Before fix: Edit is accepted, both replies now have the same name
- After fix: Error is shown, edit is rejected