### PR TITLE
fix: add null safety to getInteractionRoomId

### DIFF
--- a/src/definition/lib/IRoomInteraction.ts
+++ b/src/definition/lib/IRoomInteraction.ts
@@ -1,5 +1,5 @@
 export interface IRoomInteractionStorage {
 	storeInteractionRoomId(roomId: string): Promise<void>;
-	getInteractionRoomId(): Promise<string>;
+	getInteractionRoomId(): Promise<string | undefined>;
 	clearInteractionRoomId(): Promise<void>;
 }

--- a/src/storage/RoomInteraction.ts
+++ b/src/storage/RoomInteraction.ts
@@ -30,7 +30,7 @@ export class RoomInteractionStorage implements IRoomInteractionStorage {
 		);
 	}
 
-	public async getInteractionRoomId(): Promise<string> {
+	public async getInteractionRoomId(): Promise<string | undefined> {
 		const association = new RocketChatAssociationRecord(
 			RocketChatAssociationModel.USER,
 			`${this.userId}#RoomId`,
@@ -38,7 +38,7 @@ export class RoomInteractionStorage implements IRoomInteractionStorage {
 		const [result] = (await this.persistenceRead.readByAssociation(
 			association,
 		)) as Array<{ roomId: string }>;
-		return result.roomId;
+		return result?.roomId;
 	}
 
 	public async clearInteractionRoomId(): Promise<void> {


### PR DESCRIPTION
## Problem

`RoomInteractionStorage.getInteractionRoomId()` crashes with a `TypeError` when no room interaction record exists in persistence for the user.

The method destructures the first element from `readByAssociation()`, but if the persistence returns an empty array (no record found), `result` is `undefined` — and calling `.roomId` on it throws:

```
TypeError: Cannot read properties of undefined (reading 'roomId')
```

This can happen when the app's persistence is cleared while a user still has the contextual bar open, or during app reinstalls/updates where previous persistence data is lost. Both `ExecuteBlockActionHandler` and `ExecuteViewSubmitHandler` call this method, so the crash can surface during any block action or modal submit.

## Fix

- Use optional chaining (`result?.roomId`) so the method safely returns `undefined` instead of throwing
- Update the return type to `Promise<string | undefined>` in both the implementation and the `IRoomInteractionStorage` interface so callers are aware the value may not exist

The callers already handle this gracefully — `ExecuteBlockActionHandler` falls back to `roomPersistance` when `roomId` is falsy, and `getRoomReader().getById(undefined)` returns `undefined` which is handled downstream.

## Changes

- **`src/storage/RoomInteraction.ts`** — `result.roomId` → `result?.roomId`, return type updated
- **`src/definition/lib/IRoomInteraction.ts`** — interface return type updated to match
