### PR TITLE
fix: add missing await on async storage and UI update calls

### DIFF
--- a/src/commands/CommandUtility.ts
+++ b/src/commands/CommandUtility.ts
@@ -52,7 +52,7 @@ export class CommandUtility implements ICommandUtility {
 			this.read.getPersistenceReader(),
 			this.sender.id,
 		);
-		roomInteractionStorage.storeInteractionRoomId(this.room.id);
+		await roomInteractionStorage.storeInteractionRoomId(this.room.id);
 
 		const handler = new Handler({
 			app: this.app,

--- a/src/handlers/ExecuteViewSubmitHandler.ts
+++ b/src/handlers/ExecuteViewSubmitHandler.ts
@@ -157,7 +157,7 @@ export class ExecuteViewSubmitHandler {
 			await sendNotification(this.read, this.modify, user, room, {
 				message: successMessage,
 			});
-			this.updateList(user, room, language, triggerId);
+			await this.updateList(user, room, language, triggerId);
 			return this.context.getInteractionResponder().successResponse();
 		} else {
 			const errorMessage = `${t('Fail_Create_Reply', language, {
@@ -345,7 +345,7 @@ export class ExecuteViewSubmitHandler {
 			await sendNotification(this.read, this.modify, user, room, {
 				message: successMessage,
 			});
-			this.updateList(user, room, language, triggerId);
+			await this.updateList(user, room, language, triggerId);
 
 			return this.context.getInteractionResponder().successResponse();
 		} else {
@@ -412,7 +412,7 @@ export class ExecuteViewSubmitHandler {
 			await sendNotification(this.read, this.modify, user, room, {
 				message: successMessage,
 			});
-			this.updateList(user, room, language, triggerId);
+			await this.updateList(user, room, language, triggerId);
 
 			return this.context.getInteractionResponder().successResponse();
 		} else {

--- a/src/handlers/Handler.ts
+++ b/src/handlers/Handler.ts
@@ -204,7 +204,7 @@ export class Handler implements IHandler {
 				this.read.getPersistenceReader(),
 				this.sender.id,
 			);
-			aistorage.updateMessage(textMessage);
+			await aistorage.updateMessage(textMessage);
 			const modal = await ReplyAIModal(
 				this.app,
 				this.sender,


### PR DESCRIPTION
## Problem

I noticed several `async` storage and UI update calls that aren't being `await`ed — these fire-and-forget calls create race conditions where the next line of code runs before the persistence write actually finishes. Depending on timing and server load, this leads to intermittent issues that are hard to debug.

### 1. `aistorage.updateMessage()` in `Handler.ts`

When a user runs `/quick ai`, the handler grabs the last message text and stores it via `aistorage.updateMessage()` — but without `await`, the AI reply modal opens immediately. If the modal's `ReplyAIModal` reads the stored message before the write completes, it gets stale or empty data, and the Generate button produces a response based on nothing.

### 2. `roomInteractionStorage.storeInteractionRoomId()` in `CommandUtility.ts`

Every `/quick` command stores the current room ID so that later handlers (block actions, view submits) can retrieve it. Without `await`, the handler code continues and may open modals/contextual bars before the room ID is actually persisted. If the user interacts quickly, `getInteractionRoomId()` could return stale data or fail.

### 3. `this.updateList()` in `ExecuteViewSubmitHandler.ts` (3 places)

After creating, editing, or deleting a reply, `updateList()` refreshes the contextual bar — but it's not awaited in any of the three call sites (`handleCreate`, `handleDelete`, `handleEdit`). The handler returns `successResponse()` before the list actually refreshes, so the user might briefly see the old list or have to manually reopen the contextual bar to see their changes.

## Fix

Added `await` to all five call sites so each operation completes before execution continues.
