### PR TITLE
fix: handle Gemini error responses in /quick ai

### DIFF
--- a/src/commands/CommandUtility.ts
+++ b/src/commands/CommandUtility.ts
@@ -52,7 +52,7 @@ export class CommandUtility implements ICommandUtility {
 			this.read.getPersistenceReader(),
 			this.sender.id,
 		);
-		roomInteractionStorage.storeInteractionRoomId(this.room.id);
+		await roomInteractionStorage.storeInteractionRoomId(this.room.id);
 
 		const handler = new Handler({
 			app: this.app,

--- a/src/handlers/AIHandler.ts
+++ b/src/handlers/AIHandler.ts
@@ -121,6 +121,11 @@ class AIHandler {
 
 			return response.data.choices[0].message.content;
 		} catch (error) {
+			if (error instanceof Error && error.message.toLowerCase().includes('timeout')) {
+				this.app
+					.getLogger()
+					.error('AI request timed out while generating a response.');
+			}
 			this.app
 				.getLogger()
 				.log(`Error in handleSelfHostedModel: ${error.message}`);
@@ -186,6 +191,11 @@ class AIHandler {
 			const { choices } = response.data;
 			return choices[0].message.content;
 		} catch (error) {
+			if (error instanceof Error && error.message.toLowerCase().includes('timeout')) {
+				this.app
+					.getLogger()
+					.error('AI request timed out while generating a response.');
+			}
 			this.app.getLogger().log(`Error in handleOpenAI: ${error.message}`);
 			return t('AI_Something_Went_Wrong', this.language);
 		}
@@ -256,17 +266,32 @@ class AIHandler {
 				},
 			);
 
-			if (!response || !response.content) {
-				this.app
-					.getLogger()
-					.log('No response content received from AI.');
+			if (!response || !response.data) {
+				console.log('No response data received from Gemini.');
 				return t('AI_Something_Went_Wrong', this.language);
 			}
 
 			const data = response.data;
-			return data.candidates[0].content.parts[0].text;
+			if (data?.error?.message) {
+				console.log(`Gemini error response: ${JSON.stringify(data.error)}`);
+				return data.error.message;
+			}
+
+			const generatedText = data?.candidates?.[0]?.content?.parts?.[0]?.text;
+
+			if (!generatedText) {
+				console.log(`Unexpected Gemini response: ${JSON.stringify(data)}`);
+				return t('AI_Something_Went_Wrong', this.language);
+			}
+
+			return generatedText;
 		} catch (error) {
-			this.app.getLogger().log(`Error in handleGemini: ${error.message}`);
+			if (error instanceof Error && error.message.toLowerCase().includes('timeout')) {
+				this.app
+					.getLogger()
+					.error('AI request timed out while generating a response.');
+			}
+			this.app.getLogger().error(`Error in handleGemini: ${error.message}`);
 			return t('AI_Something_Went_Wrong', this.language);
 		}
 	}

--- a/src/handlers/ExecuteActionButtonHandler.ts
+++ b/src/handlers/ExecuteActionButtonHandler.ts
@@ -44,7 +44,7 @@ export class ExecuteActionButtonHandler {
 			this.read.getPersistenceReader(),
 			user.id,
 		);
-		roomInteractionStorage.storeInteractionRoomId(room.id);
+		await roomInteractionStorage.storeInteractionRoomId(room.id);
 
 		const handler = new Handler({
 			app: this.app,

--- a/src/handlers/ExecuteBlockActionHandler.ts
+++ b/src/handlers/ExecuteBlockActionHandler.ts
@@ -250,6 +250,13 @@ export class ExecuteBlockActionHandler {
 				);
 				const message = await aiStorage.getMessage();
 				const prompt = await aiStorage.getPrompt();
+				if (!message.trim()) {
+					console.log('AI generate requested without a stored source message.');
+					return this.context.getInteractionResponder().errorResponse();
+				}
+				if (!prompt.trim()) {
+					console.log('AI generate requested without a prompt.');
+				}
 
 				const Preference = await userPreference.getUserPreference();
 

--- a/src/handlers/Handler.ts
+++ b/src/handlers/Handler.ts
@@ -204,7 +204,7 @@ export class Handler implements IHandler {
 				this.read.getPersistenceReader(),
 				this.sender.id,
 			);
-			aistorage.updateMessage(textMessage);
+			await aistorage.updateMessage(textMessage);
 			const modal = await ReplyAIModal(
 				this.app,
 				this.sender,
@@ -227,8 +227,13 @@ export class Handler implements IHandler {
 				await this.modify
 					.getUiController()
 					.openSurfaceView(modal, { triggerId }, this.sender);
+			} else {
+				this.app
+					.getLogger()
+					.warn('replyUsingAI could not open the modal because triggerId was missing.');
 			}
 			return;
 		}
+		this.app.getLogger().warn('replyUsingAI found no source message to use.');
 	}
 }


### PR DESCRIPTION
## Issue(s)

Fixes #82

Related to Gemini failures in `/quick ai` when the API returns an error payload instead of generated candidate text.

## Acceptance Criteria fulfillment

- [x] Handle Gemini responses that do not include `candidates`
- [x] Return Gemini error messages when the API responds with an explicit `error.message`
- [x] Preserve the existing fallback message for unexpected response shapes
- [x] Keep supporting async state updates in the AI flow awaited where later interactions depend on persisted state
- [x] Include small debugging-oriented changes used to verify the failing Gemini execution path

## Proposed changes (including videos or screenshots)

This PR improves Gemini response handling in `/quick ai`.

Previously, the Gemini execution path assumed that every successful-looking response contained generated text at:

`response.data.candidates[0].content.parts[0].text`

In practice, Gemini can return an error payload instead, for example when the model is overloaded or temporarily unavailable. In those cases, `candidates` may be missing, which caused the quick AI flow to fail.

This change:

- checks for `response.data.error.message`
- returns the provider error message when available
- safely handles responses where generated candidate text is missing
- keeps the existing fallback behavior for unexpected response shapes

In addition to the Gemini response fix, this PR also includes a few small supporting changes found during debugging of the `/quick ai` flow:

- awaits persistence writes where later interactions depend on stored room/message state
- adds small defensive checks for missing AI source message / prompt during Generate
- keeps minimal debugging-oriented changes used to confirm the failing runtime path while investigating the issue

Together, these changes make the Gemini failure case safer to handle and make the `/quick ai` interaction flow a bit more reliable while staying narrowly scoped to the issue being fixed.


## Further comments

This PR is primarily scoped to Gemini runtime response handling in `/quick ai`.

The main functional fix is the safer handling of Gemini error payloads and missing candidate text. The additional async/debug-related changes are small supporting changes discovered during investigation, intended to make the AI flow more reliable and easier to reason about without redesigning the feature.
