### PR TITLE
fix: handle Gemini error responses in quick ai

### DIFF
--- a/src/handlers/AIHandler.ts
+++ b/src/handlers/AIHandler.ts
@@ -256,15 +256,25 @@ class AIHandler {
 				},
 			);
 
-			if (!response || !response.content) {
-				this.app
-					.getLogger()
-					.log('No response content received from AI.');
+			if (!response || !response.data) {
+				console.log('No response data received from Gemini.');
 				return t('AI_Something_Went_Wrong', this.language);
 			}
 
 			const data = response.data;
-			return data.candidates[0].content.parts[0].text;
+			if (data?.error?.message) {
+				console.log(`Gemini error response: ${JSON.stringify(data.error)}`);
+				return data.error.message;
+			}
+
+			const generatedText = data?.candidates?.[0]?.content?.parts?.[0]?.text;
+
+			if (!generatedText) {
+				console.log(`Unexpected Gemini response: ${JSON.stringify(data)}`);
+				return t('AI_Something_Went_Wrong', this.language);
+			}
+
+			return generatedText;
 		} catch (error) {
 			this.app.getLogger().log(`Error in handleGemini: ${error.message}`);
 			return t('AI_Something_Went_Wrong', this.language);


### PR DESCRIPTION
## Issue(s)

Related to Gemini failures in `/quick ai` when the API returns an error payload instead of generated candidate text.
fixes #82

## Acceptance Criteria fulfillment

- [x] Handle Gemini responses that do not include `candidates`
- [x] Return Gemini error messages when the API responds with an explicit `error.message`
- [x] Preserve the existing fallback message for unexpected response shape `t('AI_Something_Went_Wrong', this.language)`.

## Proposed changes (including videos or screenshots)

This PR improves Gemini response handling in `/quick ai`.

Previously, the Gemini execution path assumed that every successful-looking response contained generated text at:

`response.data.candidates[0].content.parts[0].text`

In practice, Gemini can return an error payload instead, for example when the model is overloaded or temporarily unavailable. In those cases, `candidates` may be missing, which caused the quick AI flow to fail.

This change:

- checks for `response.data.error.message`
- returns the provider error message when available
- safely handles responses where generated candidate text is missing
- keeps the existing fallback behavior for unexpected response shapes

<img width="1481" height="377" alt="image" src="https://github.com/user-attachments/assets/7cd4de84-5b2f-417a-86e5-bb97b275e63b" />

## Further comments
`console.log` is used here for debugging because it was the most reliable way to inspect the Gemini response payload in the current local setup run, whereas `this.app.getLogger()` output was not consistently visible during investigation.

This PR is intentionally scoped to Gemini runtime response handling only.

It does not change the broader `/quick ai` interaction flow or AI configuration behavior.
